### PR TITLE
feat: add delete item tags by itemId task

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,0 @@
-export enum TAGS {
-  PUBLIC = 'public-item',
-  PUBLISHED = 'published-item',
-}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,4 @@
+export enum TAGS {
+  PUBLIC = 'public-item',
+  PUBLISHED = 'published-item',
+}

--- a/src/db-service.ts
+++ b/src/db-service.ts
@@ -299,4 +299,22 @@ export class ItemTagService {
       )
       .then(({ rows }) => rows);
   }
+
+  /**
+   * Delete item-tags of given item
+   * @param itemPath item_path of given item
+   * @param tagIds a list of tags need to be deleted
+   * @param transactionHandler Database transaction handler
+   */
+  async deleteItemTagsByItemId(itemPath: string, tagIds: string[], transactionHandler: TrxHandler): Promise<number> {
+    return transactionHandler
+      .query<ItemTag>(
+        sql`
+        DELETE FROM item_tag
+        WHERE item_path = ${itemPath} AND tag_id IN (${sql.join(tagIds, sql`, `)})
+        RETURNING *
+      `,
+      )
+      .then(({ rows }) => rows.length);
+  }
 }

--- a/src/task-manager.ts
+++ b/src/task-manager.ts
@@ -126,10 +126,11 @@ export class TaskManager implements ItemTagTaskManager {
     );
   }
 
-  createDeleteItemTagsByItemIdTask(member: Member, itemId: string): DeleteItemTagsByItemIdTask {
+  createDeleteItemTagsByItemIdTask(member: Member, itemId: string, tagIds: string[]): DeleteItemTagsByItemIdTask {
     return new DeleteItemTagsByItemIdTask(
       member,
       itemId,
+      tagIds,
       this.itemService,
       this.itemMembershipService,
       this.itemTagService,

--- a/src/task-manager.ts
+++ b/src/task-manager.ts
@@ -17,6 +17,7 @@ import { BaseItemTagTask } from './tasks/base-item-tag-task';
 import { GetItemsItemTagsTask } from './tasks/get-items-item-tags-task';
 import { ItemTagTaskManager } from './interfaces/item-tag-task-manager';
 import { GetAvailableTagsTask } from './tasks/get-available-tags-task';
+import { DeleteItemTagsByItemIdTask } from './tasks/delete-item-tags-by-item-id-task';
 
 export class TaskManager implements ItemTagTaskManager {
   private itemService: ItemService;
@@ -54,6 +55,9 @@ export class TaskManager implements ItemTagTaskManager {
   }
   getGetAvailableTagsName(): string {
     return GetAvailableTagsTask.name;
+  }
+  getDeleteItemTagsByItemIdTaskName(): string {
+    return DeleteItemTagsByItemIdTask.name;
   }
 
   // CRUD
@@ -119,6 +123,16 @@ export class TaskManager implements ItemTagTaskManager {
       this.itemTagService,
       this.itemService,
       this.itemMembershipService,
+    );
+  }
+
+  createDeleteItemTagsByItemIdTask(member: Member, itemId: string): DeleteItemTagsByItemIdTask {
+    return new DeleteItemTagsByItemIdTask(
+      member,
+      itemId,
+      this.itemService,
+      this.itemMembershipService,
+      this.itemTagService,
     );
   }
 }

--- a/src/tasks/delete-item-tags-by-item-id-task.ts
+++ b/src/tasks/delete-item-tags-by-item-id-task.ts
@@ -1,0 +1,33 @@
+// global
+import { DatabaseTransactionHandler, ItemMembershipService, ItemService, Member } from 'graasp';
+import { TAGS } from '../constants';
+import { ItemTagService } from '../db-service';
+import { BaseItemTagTask } from './base-item-tag-task';
+
+export class DeleteItemTagsByItemIdTask extends BaseItemTagTask<Member, number> {
+  get name(): string {
+    return DeleteItemTagsByItemIdTask.name;
+  }
+
+  private itemId: string;
+
+  constructor(
+    member: Member,
+    itemId: string,
+    itemService: ItemService,
+    itemMembershipService: ItemMembershipService,
+    itemTagService: ItemTagService,
+  ) {
+    super(member, itemTagService, itemService, itemMembershipService);
+    this.itemId = itemId;
+  }
+
+  async run(handler: DatabaseTransactionHandler): Promise<void> {
+    this.status = 'RUNNING';
+    const itemPath = this.itemId.replace(/-/g, '_');
+    const tags = (await this.itemTagService.getAllTags(handler))?.filter((tag) => tag?.name === TAGS.PUBLIC || tag?.name === TAGS.PUBLISHED);
+    const tagIds = tags?.map((tag) => tag?.id);
+    this._result = await this.itemTagService.deleteItemTagsByItemId(itemPath, tagIds, handler);
+    this.status = 'OK';
+  }
+}

--- a/src/tasks/delete-item-tags-by-item-id-task.ts
+++ b/src/tasks/delete-item-tags-by-item-id-task.ts
@@ -1,6 +1,5 @@
 // global
 import { DatabaseTransactionHandler, ItemMembershipService, ItemService, Member } from 'graasp';
-import { TAGS } from '../constants';
 import { ItemTagService } from '../db-service';
 import { BaseItemTagTask } from './base-item-tag-task';
 
@@ -10,24 +9,25 @@ export class DeleteItemTagsByItemIdTask extends BaseItemTagTask<Member, number> 
   }
 
   private itemId: string;
+  private tagIds: string[];
 
   constructor(
     member: Member,
     itemId: string,
+    tagIds: string[],
     itemService: ItemService,
     itemMembershipService: ItemMembershipService,
     itemTagService: ItemTagService,
   ) {
     super(member, itemTagService, itemService, itemMembershipService);
     this.itemId = itemId;
+    this.tagIds = tagIds;
   }
 
   async run(handler: DatabaseTransactionHandler): Promise<void> {
     this.status = 'RUNNING';
     const itemPath = this.itemId.replace(/-/g, '_');
-    const tags = (await this.itemTagService.getAllTags(handler))?.filter((tag) => tag?.name === TAGS.PUBLIC || tag?.name === TAGS.PUBLISHED);
-    const tagIds = tags?.map((tag) => tag?.id);
-    this._result = await this.itemTagService.deleteItemTagsByItemId(itemPath, tagIds, handler);
+    this._result = await this.itemTagService.deleteItemTagsByItemId(itemPath, this.tagIds, handler);
     this.status = 'OK';
   }
 }


### PR DESCRIPTION
close #20 

I've added the task to delete itemTags by Itemid into this plugin. 
Instead of use options to obtain the tag-id of PUBLISHED and PUBLIC, I actually use the DB query getALLTag directly, which could be more dynamic.